### PR TITLE
feat: Maya2016以前の対応とTreeWidgetのフォーカスの対応

### DIFF
--- a/python/squid/tools/inspector/panels/blend_shape_panel.py
+++ b/python/squid/tools/inspector/panels/blend_shape_panel.py
@@ -6,6 +6,7 @@ from squid.core.libs.maya import blend_shape
 from squid.core.libs.qt.widgets import collapse_widget
 from squid.tools.inspector.panels import panel_base
 
+from squid.vendor.Qt import QtCore
 from squid.vendor.Qt import QtWidgets
 
 
@@ -31,6 +32,7 @@ class BlendShapePanel(panel_base.PanelBase):
         root_layout.addWidget(material_widget)
 
         tree_widget = QtWidgets.QTreeWidget()
+        tree_widget.setFocusPolicy(QtCore.Qt.NoFocus)
         tree_widget.setHeaderHidden(True)
         tree_widget.setColumnCount(1)
 

--- a/python/squid/tools/inspector/panels/constraint_panel.py
+++ b/python/squid/tools/inspector/panels/constraint_panel.py
@@ -6,6 +6,7 @@ from squid.core.libs.maya import constraint
 from squid.core.libs.qt.widgets import collapse_widget
 from squid.tools.inspector.panels import panel_base
 
+from squid.vendor.Qt import QtCore
 from squid.vendor.Qt import QtWidgets
 
 
@@ -31,6 +32,7 @@ class ConstraintPanel(panel_base.PanelBase):
         const_widget = collapse_widget.QCollapseWidget("Constraints")
         root_layout.addWidget(const_widget)
         tree_widget = QtWidgets.QTreeWidget()
+        tree_widget.setFocusPolicy(QtCore.Qt.NoFocus)
         tree_widget.setIndentation(0)
         tree_widget.setHeaderHidden(True)
         tree_widget.setColumnCount(2)

--- a/python/squid/tools/inspector/panels/material_panel.py
+++ b/python/squid/tools/inspector/panels/material_panel.py
@@ -9,6 +9,7 @@ from squid.core.libs.maya import material
 from squid.core.libs.qt.widgets import collapse_widget
 from squid.tools.inspector.panels import panel_base
 
+from squid.vendor.Qt import QtCore
 from squid.vendor.Qt import QtWidgets
 
 
@@ -34,6 +35,7 @@ class MaterialPanel(panel_base.PanelBase):
         root_layout.addWidget(material_widget)
 
         tree_widget = QtWidgets.QTreeWidget()
+        tree_widget.setFocusPolicy(QtCore.Qt.NoFocus)
         tree_widget.setHeaderHidden(True)
         tree_widget.setColumnCount(1)
 

--- a/python/squid/tools/inspector/panels/panel_base.py
+++ b/python/squid/tools/inspector/panels/panel_base.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function
 from abc import ABCMeta
 from abc import abstractmethod
 
-import six
+from squid.vendor import six
 
 from squid.vendor.Qt import QtCore
 from squid.vendor.Qt import QtWidgets

--- a/python/squid/tools/inspector/view.py
+++ b/python/squid/tools/inspector/view.py
@@ -3,6 +3,7 @@ u"""インスペクタのView"""
 from __future__ import absolute_import, division, print_function
 
 from squid.core.libs.maya.layout import delete_window
+from squid.core.libs.maya.layout import delete_workspace_control
 from squid.core.libs.qt import maya_window
 from squid.core.libs.qt.layout import clear_layout
 from squid.core.libs.qt.stylesheet import StyleSheet
@@ -36,8 +37,7 @@ class Inspector(maya_window.MayaDockableWindow):
     def open(cls, *args):
         u"""UIを表示"""
         delete_window(cls.window_name())
-        if cmds.workspaceControl(cls.workspace_control_name(), ex=True):
-            cmds.deleteUI(cls.workspace_control_name())
+        delete_workspace_control(cls.workspace_control_name())
         win = cls()
         ui_script = cls.ui_script()
         win.show(dockable=True, uiScript=ui_script)


### PR DESCRIPTION
各パネルで項目選択後、即座にViewPortでショートカットキーが有効にならない問題の対応